### PR TITLE
Use Strided.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 GPUArrays = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Strided = "5e0ebb24-38b0-5f93-81fe-25c709ecae67"
 
 [compat]
 Adapt = "2.4, 3.1"
@@ -15,6 +16,7 @@ BenchmarkTools = "0.5"
 ChainRulesCore = "0.9.27"
 Documenter = "0.26"
 GPUArrays = "5.2.1, 6.2"
+Strided = "1.1.1"
 Zygote = "v0.6.2"
 julia = "1.3"
 
@@ -23,8 +25,8 @@ BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
 test = ["Test", "BenchmarkTools", "Documenter", "OffsetArrays", "Random", "Zygote"]

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ transmute(Diagonal(rand(10)), (3,1)) isa Matrix
 ```
 
 Calling the constructor directly `TransmutedDimsArray(A, (3,2,0,1))` simply applies the wrapper. 
-There is also a variant `transmute(A, Val((3,2,0,1)))` which works out any un-wrapping at compile-time:
+There is also a method `transmute(A, Val((3,2,0,1)))` which works out any un-wrapping at compile-time:
 
 ```julia
 using BenchmarkTools
@@ -60,4 +60,13 @@ using BenchmarkTools
 @btime reshape($A, (10,20,1,30));        #  34.479 ns (1 allocation: 80 bytes)
 ```
 
-There was going to be an eager variant `transmutedims(A, (3,2,0,1))` but for now that's absent.
+Finally, there is also an eager variant, which tries always to return a `DenseArray`, copying data if necessary. 
+It uses [Strided.jl](https://github.com/Jutho/Strided.jl) to speed this up, when possible, so should be faster than Base's `permutedims`:
+
+```julia
+transmutedims(A, (3,2,0,1)) isa Array{Float64, 4}
+transmutedims(1:3, (2,1)) isa Matrix
+
+@btime transmutedims($(rand(40,50,60)), (3,2,1));  #  57.365 μs (61 allocations: 944.62 KiB)
+@btime permutedims($(rand(40,50,60)), (3,2,1));    # 172.643 μs (2 allocations: 937.58 KiB)
+```

--- a/src/TransmuteDims.jl
+++ b/src/TransmuteDims.jl
@@ -550,8 +550,10 @@ end
 
 include("base.jl")
 
-include("gpu.jl") # this takes loading from 0.4s to 1.5s :(
+include("strided.jl") # this costs about 0.1s
 
-include("chainrules.jl")
+include("chainrules.jl") # this costs about 0.2s
+
+include("gpu.jl") # this costs just over a second
 
 end

--- a/src/TransmuteDims.jl
+++ b/src/TransmuteDims.jl
@@ -536,6 +536,22 @@ end
     end
 end
 
+# This exists for testing, with integer data it calls @generated _densecopy_permuted!
+function _float_transmutedims(data::AT, perm) where {AT <: AbstractArray{T,M}} where {T,M}
+    P = sanitise_zero(perm, Val(ndims(data)))
+    N = length(P)
+    Q = invperm_zero(P, size(data))
+    S = map(d -> d==0 ? Base.OneTo(1) : axes(data,d), P)
+    if may_reshape(AT) && M == N && P == ntuple(identity, N)
+        data
+    elseif may_reshape(AT) && increasing_or_zero(P)
+        reshape(data, S)
+    else
+        out = similar(data, float(T), S)
+        copy!(out, TransmutedDimsArray{T,N,P,Q,AT}(data))
+    end
+end
+
 """
     transmutedims!(dst, src, perm⁺)
 

--- a/src/base.jl
+++ b/src/base.jl
@@ -131,6 +131,7 @@ function _copy_into!(dst::AbstractArray, parent::AbstractArray, ::Val{P}) where 
         J = CartesianIndex(map(p -> p==0 ? 1 : I[p], P))
         dst[J] = parent[I]
     end
+    nothing
 end
 
 function Base.copyto!(dst::AbstractArray, src::TransmutedDimsArray)

--- a/src/base.jl
+++ b/src/base.jl
@@ -117,7 +117,7 @@ end
     end
     if sort(Pminus) == 1:ndims(src)
         Aex = :src
-        perm = Pminus
+        perm = Tuple(Pminus)
     else
         SA = [:(axes(src,$d)) for d in 1:ndims(src) if d in Pminus]
         Aex = :(reshape(src, ($(SA...),)))

--- a/src/base.jl
+++ b/src/base.jl
@@ -123,7 +123,7 @@ end
         Aex = :(reshape(src, ($(SA...),)))
         perm = Tuple(sortperm(Pminus))
     end
-    :(permutedims!($Bex, $Aex, $perm))
+    :(permutedims!($Bex, $Aex, $perm); nothing)
 end
 
 function _copy_into!(dst::AbstractArray, parent::AbstractArray, ::Val{P}) where {P}

--- a/src/strided.jl
+++ b/src/strided.jl
@@ -35,6 +35,9 @@ end
 
 The eager transmutedims(A, perm) should also use this?
 
+Restricted here to T,T specificaly so that _float_transmutedims(A, perm) can,
+with integer-valued A, test the alternative _densecopy_permuted!() path.
+
 =#
 
 @inline function _densecopy_permuted!(dst::Array{T}, A::StridedArray{T}, ::Val{P}) where {T,P}

--- a/src/strided.jl
+++ b/src/strided.jl
@@ -1,0 +1,42 @@
+#=
+
+StridedView allows permutations, and gap dimensions, but not Diagonal-like objects.
+Instead of storing a permutation in the type, it stores the strides in a field.
+
+Making @strided transmute(A, perm) return another StridedView will make TensorCast work,
+but is unlike the other _transmute methods, which aim to unwrap.
+
+=#
+
+using Strided: StridedView
+
+@inline function _transmute(A::StridedView{T,M}, P) where {T,M}
+    Q = invperm_zero(P, size(A))  # also checks size of dropped dimensions
+    N = length(P)
+    if M == N && P == ntuple(identity, N)  # trivial case
+        data
+    elseif unique_or_zero(P)
+        sz = map(d -> d==0 ? 1 : size(A,d), P)
+        st = map(d -> d==0 ? 0 : stride(A,d), P)
+        StridedView(A.parent, sz, st, A.offset, A.op)
+    elseif P == (1,1)
+        Diagonal(A.parent)
+    else
+        TransmutedDimsArray{T,N,P,Q,typeof(A)}(A)
+    end
+end
+
+#=
+
+The eager transmutedims(A, perm) should also use this?
+
+=#
+
+# function _densecopy_permuted!(dst::Array{T}, A::StridedArray, ::Val{P}) where {T,P}
+#     @info "strided densecopy"
+#     sz = map(d -> d==0 ? 1 : size(A,d), P)
+#     st = map(d -> d==0 ? 0 : stride(A,d), P)
+#     _A = StridedView(A, sz, st) # , 0, identity)
+#     LinearAlgebra.axpby!(one(T), _A, zero(T), dst)
+# end
+

--- a/test/speed.jl
+++ b/test/speed.jl
@@ -187,7 +187,7 @@ julia> @btime copyto!($M3, $(transpose(M2)));
 julia> @btime copyto!($M3, $(PermutedDimsArray(M2, (2,1)))); # same with M3 .=
   3.361 ms (0 allocations: 0 bytes)
 
-julia> @btime transmutedims!($M3, $M2, (2,1)); # hmm
+julia> @btime transmutedims!($M3, $M2, (2,1));
   2.647 ms (0 allocations: 0 bytes)
 
 julia> @btime copyto!($M3, $(TransmutedDimsArray(M2, (2,1))));

--- a/test/speed.jl
+++ b/test/speed.jl
@@ -211,3 +211,27 @@ julia> @btime @strided permutedims!($M3, $M2, (2,1));
 julia> @btime @strided permutedims!($T3, $T1, (3,2,1));
   520.262 μs (65 allocations: 7.38 KiB)
 
+#========== Acceleration ==========#
+
+julia> @btime $M3 .= exp.($M1');
+  7.868 ms (0 allocations: 0 bytes)
+
+julia> @btime $M3 .= exp.($(TransmutedDimsArray(M1,(2,1))));
+  7.642 ms (0 allocations: 0 bytes)
+
+julia> using Strided
+
+julia> @btime @strided $M3 .= exp.($M1');  # multi-threaded
+  3.637 ms (64 allocations: 6.66 KiB)
+
+julia> @btime @strided $M3 .= exp.($(TransmutedDimsArray(M1,(2,1))));
+  3.640 ms (64 allocations: 6.66 KiB)
+
+julia> using LoopVectorization
+
+julia> @btime @avx $M3 .= exp.($M1');  # vectorised
+  1.893 ms (0 allocations: 0 bytes)
+
+julia> @btime @avx $M3 .= exp.($(TransmutedDimsArray(M1,(2,1))));
+  7.547 ms (0 allocations: 0 bytes)
+

--- a/test/speed.jl
+++ b/test/speed.jl
@@ -187,8 +187,11 @@ julia> @btime copyto!($M3, $(transpose(M2)));
 julia> @btime copyto!($M3, $(PermutedDimsArray(M2, (2,1)))); # same with M3 .=
   3.361 ms (0 allocations: 0 bytes)
 
+julia> @btime transmutedims!($M3, $M2, (2,1)); # hmm
+  2.647 ms (0 allocations: 0 bytes)
+
 julia> @btime copyto!($M3, $(TransmutedDimsArray(M2, (2,1))));
-  1.569 ms (0 allocations: 0 bytes)
+  606.967 μs (62 allocations: 6.66 KiB)
 
 # three dimensions
 
@@ -199,9 +202,23 @@ julia> @btime copyto!($T3, $(PermutedDimsArray(T1, (3,2,1))));
   4.528 ms (0 allocations: 0 bytes)
 
 julia> @btime copyto!($T3, $(TransmutedDimsArray(T1, (3,2,1))));
-  2.292 ms (0 allocations: 0 bytes)
+  542.873 μs (61 allocations: 7.22 KiB)
 
-# fast library
+# allocating forms
+
+julia> @btime permutedims($M2);
+  1.599 ms (2 allocations: 7.63 MiB)
+
+julia> @btime transmutedims($M2);
+  808.915 μs (65 allocations: 7.64 MiB)
+
+julia> @btime permutedims($T1, (3,2,1));
+  2.459 ms (2 allocations: 7.63 MiB)
+
+julia> @btime transmutedims($T1, (3,2,1));
+  737.701 μs (62 allocations: 7.64 MiB)
+
+# fast library behind this
 
 julia> using Strided
 


### PR DESCRIPTION
This is wanted for TensorCast's `@strided` mode. 

But might be nice in general for `transmutedims` to be faster than Base's `permutedims`, there's no great interface for that elsewhere. 

Strided.jl is very light-weight, about 0.1s.